### PR TITLE
Replace all dots (`.`) when constructing `elmModulePath`

### DIFF
--- a/src/ElmSvgModulesTransformer.js
+++ b/src/ElmSvgModulesTransformer.js
@@ -26,7 +26,7 @@ module.exports = new Transformer({
       outputModuleDir = "src",
     }) => {
       const elmModulePath = outputModuleName
-        .replace("g.", path.sep)
+        .replace(/\./g, path.sep)
         .concat(".elm");
       const resolvedModulePath = path.join(outputModuleDir, elmModulePath);
       await fs.mkdir(path.dirname(resolvedModulePath), { recursive: true });

--- a/src/ElmSvgModulesTransformer.js
+++ b/src/ElmSvgModulesTransformer.js
@@ -26,7 +26,7 @@ module.exports = new Transformer({
       outputModuleDir = "src",
     }) => {
       const elmModulePath = outputModuleName
-        .replace(".", path.sep)
+        .replace("g.", path.sep)
         .concat(".elm");
       const resolvedModulePath = path.join(outputModuleDir, elmModulePath);
       await fs.mkdir(path.dirname(resolvedModulePath), { recursive: true });

--- a/src/ElmSvgModulesTransformer.js
+++ b/src/ElmSvgModulesTransformer.js
@@ -26,7 +26,7 @@ module.exports = new Transformer({
       outputModuleDir = "src",
     }) => {
       const elmModulePath = outputModuleName
-        .replace(/\./g, path.sep)
+        .replaceAll(".", path.sep)
         .concat(".elm");
       const resolvedModulePath = path.join(outputModuleDir, elmModulePath);
       await fs.mkdir(path.dirname(resolvedModulePath), { recursive: true });


### PR DESCRIPTION
Fixes #3 

```
> "Acme.Factory.Icons".replace(".","/")
'Acme/Factory.Icons'

> "Acme.Factory.Icons".replace("g.","/")
'Acme.Factory.Icons'
```